### PR TITLE
Add config to disable anvil recipes; prevent crash when diamond tool recipes don't exist

### DIFF
--- a/common/net/insane96mcp/carbonado/events/AnvilUpdate.java
+++ b/common/net/insane96mcp/carbonado/events/AnvilUpdate.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import net.insane96mcp.carbonado.Carbonado;
 import net.insane96mcp.carbonado.init.ModItems;
+import net.insane96mcp.carbonado.lib.Properties;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.init.Items;
@@ -36,6 +37,8 @@ public class AnvilUpdate {
 		
 	@SubscribeEvent
 	public static void EventAnvilOuput(AnvilUpdateEvent event) {
+		if (!Properties.config.tools.enableAnvilCrafting)
+			return;
 		
 		ItemStack left = event.getLeft();
 		ItemStack right = event.getRight();
@@ -49,6 +52,8 @@ public class AnvilUpdate {
 				continue;
 			
 			IRecipe recipe = CraftingManager.getRecipe(left.getItem().getRegistryName());
+			if (recipe == null)
+				continue;
 
 			int carbonadoAmount = 0;
 			for (Ingredient ingredient : recipe.getIngredients()) {

--- a/common/net/insane96mcp/carbonado/lib/Properties.java
+++ b/common/net/insane96mcp/carbonado/lib/Properties.java
@@ -39,5 +39,13 @@ public class Properties {
 			@Comment("Maximum shards that can drop a single carbonado")
 			public int maxCount = 24;
 		}
+
+		public Tools tools = new Tools();
+
+		public static class Tools {
+			@Name("Enable Anvil Crafting")
+			@Comment("Enable crafting Carbonado tools in the Anvil; disable only if other ways of obtaining Carbonado tools exist")
+			public boolean enableAnvilCrafting = true;
+		}
 	}
 }


### PR DESCRIPTION
This commit adds two things:

1. A config to disable the Anvil recipes for Carbonado tools (mainly for pack devs that want to provide other ways of obtaining them)
1. A small patch to prevent a crash when the default recipe for one of the diamond tools has been removed (e.g. by CraftTweaker)